### PR TITLE
Added support for ESC [ <n> A / B / C / D -- move cursor

### DIFF
--- a/ansicolor-w32.c
+++ b/ansicolor-w32.c
@@ -299,6 +299,34 @@ retry:
             coord.Y = csbi.srWindow.Bottom;
           SetConsoleCursorPosition(handle, coord);
           break;
+        case 'A': // Move up
+          GetConsoleScreenBufferInfo(handle, &csbi);
+          coord = csbi.dwCursorPosition;
+          if (v[0] != -1) coord.Y = coord.Y - v[0];
+          if (coord.Y < csbi.srWindow.Top) coord.Y = csbi.srWindow.Top;
+          SetConsoleCursorPosition(handle, coord);
+          break;
+        case 'B': // Move down
+          GetConsoleScreenBufferInfo(handle, &csbi);
+          coord = csbi.dwCursorPosition;
+          if (v[0] != -1) coord.Y = coord.Y + v[0];
+          if (coord.Y > csbi.srWindow.Bottom) coord.Y = csbi.srWindow.Bottom;
+          SetConsoleCursorPosition(handle, coord);
+          break;
+        case 'C': // Move forward / right
+          GetConsoleScreenBufferInfo(handle, &csbi);
+          coord = csbi.dwCursorPosition;
+          if (v[0] != -1) coord.X = coord.X + v[0];
+          if (coord.X > csbi.srWindow.Right) coord.X = csbi.srWindow.Right;
+          SetConsoleCursorPosition(handle, coord);
+          break;
+        case 'D': // Move backward / left
+          GetConsoleScreenBufferInfo(handle, &csbi);
+          coord = csbi.dwCursorPosition;
+          if (v[0] != -1) coord.X = coord.X - v[0];
+          if (coord.X < csbi.srWindow.Left) coord.X = csbi.srWindow.Left;
+          SetConsoleCursorPosition(handle, coord);
+          break;
         default:
           break;
       }


### PR DESCRIPTION
Added support for the A / B / C / D codes that move the cursor up / down / right / left, respectively.

Code copy/pasted from the `H` case.

Test string:
```
  printf("\033[7A\033[3C\033[1;35m BASH \033[7B\033[6D");
  printf("\x1b[6A\033[3C\x1b[1;35m HELLO \x1b[7B\x1b[6D");
```

Comparing Linux (native support):
![image](https://user-images.githubusercontent.com/2192439/45233525-41933000-b290-11e8-9668-78e2a1dc3db1.png)

To Windows:
![image](https://user-images.githubusercontent.com/2192439/45233559-5a9be100-b290-11e8-88ae-a6542b49ab97.png)
